### PR TITLE
Fix _unresolved type `Error`_ in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ use mpu6050::*;
 use linux_embedded_hal::{I2cdev, Delay};
 use i2cdev::linux::LinuxI2CError;
 
-fn main() -> Result<(), Error<LinuxI2CError>> {
+fn main() -> Result<(), Mpu6050Error<LinuxI2CError>> {
     let i2c = I2cdev::new("/dev/i2c-1")
-        .map_err(Error::I2c)?;
+        .map_err(Mpu6050Error::I2c)?;
 
     let delay = Delay;
 


### PR DESCRIPTION
```
error[E0433]: failed to resolve: use of undeclared type or module `Error`
 --> src/main.rs:7:18
  |
7 |         .map_err(Error::I2c)?;
  |                  ^^^^^ use of undeclared type or module `Error`

error[E0412]: cannot find type `Error` in this scope
 --> src/main.rs:5:25
  |
5 | fn main() -> Result<(), Error<LinuxI2CError>> {
  |                         ^^^^^ not found in this scope
```