### PR TITLE
Add configuration options

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -20,7 +20,11 @@ pub fn get_bits(mut byte: u8, bit_start: u8, length: u8) -> u8 {
     // in SOME cases, you get an 'attempt to subtract with overflow' exception, when
     // bitstart - length + 1 = 0
     // therefore just "cut off" at 0 shift
-    let mask_shift: u8 = if bit_start < length { 0 } else { bit_start - length + 1 };
+    let mask_shift: u8 = if bit_start < length {
+        0
+    } else {
+        bit_start - length + 1
+    };
     let mask: u8 = ((1 << length) - 1) << mask_shift;
     byte &= mask as u8;
     byte >>= mask_shift;
@@ -39,26 +43,34 @@ pub fn set_bit(byte: &mut u8, n: u8, enable: bool) {
 /// Fill bits bitstart-bitstart+length in byte with data
 pub fn set_bits(byte: &mut u8, bit_start: u8, length: u8, mut data: u8) {
     /*
-              010 value to write
-         76543210 bit numbers
-            xxx   args: bit_start=4, length=3
-         00011100 mask byte
-         10101111 original value (sample)
-         10100011 original & ~mask
-         10101011 masked | value
-     */
+             010 value to write
+        76543210 bit numbers
+           xxx   args: bit_start=4, length=3
+        00011100 mask byte
+        10101111 original value (sample)
+        10100011 original & ~mask
+        10101011 masked | value
+    */
 
     // without mask_shift, strange behavior occurs, wenn bit_start < length.
     // e.g. bit_start=2, length = 2
     // in SOME cases, you get an 'attempt to subtract with overflow' exception, when
     // bitstart - length + 1 = 0
     // therefore just "cut off" at 0 shift
-    let mask_shift: u8 = if bit_start < length { 0 } else { bit_start - length + 1 };
+    let mask_shift: u8 = if bit_start < length {
+        0
+    } else {
+        bit_start - length + 1
+    };
     let mask: u8 = ((1 << length) - 1) << mask_shift;
-    data <<= mask_shift;                // shift data into correct position
-    data &= mask;                       // zero all non-important bits in data
-    *byte &= !(mask);                   // zero all important bits in existing byte
-    *byte |= data;                      // combine data with existing byte
+    // shift data into correct position
+    data <<= mask_shift;
+    // zero all non-important bits in data
+    data &= mask;
+    // zero all important bits in existing byte
+    *byte &= !(mask);
+    // combine data with existing byte
+    *byte |= data;
 }
 
 #[cfg(test)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -7,7 +7,6 @@
 //! * Register map (rev 3.2): https://arduino.ua/docs/RM-MPU-6000A.pdf
 //! * Datasheet (rev 3.2): https://www.cdiweb.com/datasheets/invensense/ps-mpu-6000a.pdf
 
-
 /// Gyro Sensitivity
 ///
 /// Measurements are scaled like this:
@@ -49,13 +48,13 @@ pub const GYRO_REGY_H: u8 = 0x45;
 /// High Byte Register Gyro z orientation
 pub const GYRO_REGZ_H: u8 = 0x47;
 /// High Byte Register Calc roll
-pub const ACC_REGX_H : u8= 0x3b;
+pub const ACC_REGX_H: u8 = 0x3b;
 /// High Byte Register Calc pitch
-pub const ACC_REGY_H : u8= 0x3d;
+pub const ACC_REGY_H: u8 = 0x3d;
 /// High Byte Register Calc yaw
-pub const ACC_REGZ_H : u8= 0x3f;
+pub const ACC_REGZ_H: u8 = 0x3f;
 /// High Byte Register Temperature
-pub const TEMP_OUT_H : u8= 0x41;
+pub const TEMP_OUT_H: u8 = 0x41;
 /// Slave address of Mpu6050
 pub const DEFAULT_SLAVE_ADDR: u8 = 0x68;
 /// Internal register to check slave addr
@@ -64,7 +63,7 @@ pub const WHOAMI: u8 = 0x75;
 /// Describes a bit block from bit number 'bit' to 'bit'+'length'
 pub struct BitBlock {
     pub bit: u8,
-    pub length: u8
+    pub length: u8,
 }
 
 #[allow(non_camel_case_types)]
@@ -76,9 +75,9 @@ impl CONFIG {
     /// Base Address
     pub const ADDR: u8 = 0x1a;
     /// external Frame Synchronisation (FSYNC)
-    pub const EXT_SYNC_SET: BitBlock = BitBlock { bit: 5, length: 3};
+    pub const EXT_SYNC_SET: BitBlock = BitBlock { bit: 5, length: 3 };
     /// Digital Low Pass Filter (DLPF) config
-    pub const DLPF_CFG: BitBlock = BitBlock { bit: 2, length: 3};
+    pub const DLPF_CFG: BitBlock = BitBlock { bit: 2, length: 3 };
 }
 
 #[allow(non_camel_case_types)]
@@ -113,9 +112,9 @@ impl ACCEL_CONFIG {
     /// Accel z axis self test bit
     pub const ZA_ST: u8 = 5;
     /// Accel Config FS_SEL
-    pub const FS_SEL: BitBlock = BitBlock { bit: 4, length: 2};
+    pub const FS_SEL: BitBlock = BitBlock { bit: 4, length: 2 };
     /// Accel Config ACCEL_HPF
-    pub const ACCEL_HPF: BitBlock = BitBlock { bit: 2, length: 3};
+    pub const ACCEL_HPF: BitBlock = BitBlock { bit: 2, length: 3 };
 }
 
 #[allow(non_camel_case_types)]
@@ -221,11 +220,11 @@ impl MOT_DETECT_CONTROL {
     /// Base Address
     pub const ADDR: u8 = 0x69;
     /// Additional delay
-    pub const ACCEL_ON_DELAY: BitBlock = BitBlock { bit: 5, length: 2};
+    pub const ACCEL_ON_DELAY: BitBlock = BitBlock { bit: 5, length: 2 };
     ///  Free Fall count
-    pub const FF_COUNT: BitBlock = BitBlock { bit: 3, length: 2};
+    pub const FF_COUNT: BitBlock = BitBlock { bit: 3, length: 2 };
     /// Motion Detection cound
-    pub const MOT_COUNT: BitBlock = BitBlock { bit: 1, length: 2};
+    pub const MOT_COUNT: BitBlock = BitBlock { bit: 1, length: 2 };
 }
 
 #[allow(non_camel_case_types)]
@@ -257,7 +256,7 @@ impl PWR_MGMT_2 {
     /// Base Address
     pub const ADDR: u8 = 0x6c;
     /// Wake up frequency
-    pub const LP_WAKE_CTRL: BitBlock = BitBlock { bit: 7, length: 2};
+    pub const LP_WAKE_CTRL: BitBlock = BitBlock { bit: 7, length: 2 };
     /// disable accel axis x
     pub const STBY_XA: u8 = 5;
     /// disable accel axis y
@@ -302,12 +301,11 @@ pub enum ACCEL_HPF {
     _0P63 = 4,
     /// When triggered, the filter holds the present sample. The filter output will be the
     /// difference between the input sample and the held sample
-    _HOLD = 7
+    _HOLD = 7,
 }
 
 impl From<u8> for ACCEL_HPF {
-    fn from(range: u8) -> Self
-    {
+    fn from(range: u8) -> Self {
         match range {
             0 => ACCEL_HPF::_RESET,
             1 => ACCEL_HPF::_5,
@@ -353,7 +351,7 @@ impl From<u8> for CLKSEL {
             5 => CLKSEL::EXT_19P2,
             6 => CLKSEL::RESERV,
             7 => CLKSEL::STOP,
-            _ => CLKSEL::GXAXIS
+            _ => CLKSEL::GXAXIS,
         }
     }
 }
@@ -385,27 +383,25 @@ pub enum GyroRange {
 }
 
 impl From<u8> for GyroRange {
-    fn from(range: u8) -> Self
-    {
+    fn from(range: u8) -> Self {
         match range {
             0 => GyroRange::D250,
             1 => GyroRange::D500,
             2 => GyroRange::D1000,
             3 => GyroRange::D2000,
-            _ => GyroRange::D250
+            _ => GyroRange::D250,
         }
     }
 }
 
 impl From<u8> for AccelRange {
-    fn from(range: u8) -> Self
-    {
+    fn from(range: u8) -> Self {
         match range {
             0 => AccelRange::G2,
             1 => AccelRange::G4,
             2 => AccelRange::G8,
             3 => AccelRange::G16,
-            _ => AccelRange::G2
+            _ => AccelRange::G2,
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -60,6 +60,9 @@ pub const DEFAULT_SLAVE_ADDR: u8 = 0x68;
 /// Internal register to check slave addr
 pub const WHOAMI: u8 = 0x75;
 
+// Sample Rate Divisor register
+pub const SMPLRT_DIV: u8 = 0x19;
+
 /// Describes a bit block from bit number 'bit' to 'bit'+'length'
 pub struct BitBlock {
     pub bit: u8,

--- a/src/device.rs
+++ b/src/device.rs
@@ -274,6 +274,8 @@ impl PWR_MGMT_2 {
     pub const STBY_YG: u8 = 1;
     /// disable gyro  axis z
     pub const STBY_ZG: u8 = 0;
+    /// cycle rate
+    pub const CYCLE_RATE: BitBlock = BitBlock { bit: 6, length: 2 };
 }
 
 #[allow(non_camel_case_types)]
@@ -288,6 +290,20 @@ pub enum LP_WAKE_CTRL {
     _5,
     /// 10 Hz
     _10,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// Cycle rates
+pub enum CYCLE_RATE {
+    /// 1.25 Hz
+    _1_25_HZ = 0,
+    /// 5 Hz
+    _5_HZ = 1,
+    /// 20 Hz
+    _20_HZ = 2,
+    /// 40 Hz
+    _40_HZ = 3,
 }
 
 #[allow(non_camel_case_types)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -81,6 +81,8 @@ impl CONFIG {
     pub const EXT_SYNC_SET: BitBlock = BitBlock { bit: 5, length: 3 };
     /// Digital Low Pass Filter (DLPF) config
     pub const DLPF_CFG: BitBlock = BitBlock { bit: 2, length: 3 };
+    /// filter bandwidth
+    pub const BANDWIDTH: BitBlock = BitBlock { bit: 0, length: 3 };
 }
 
 #[allow(non_camel_case_types)]
@@ -286,6 +288,26 @@ pub enum LP_WAKE_CTRL {
     _5,
     /// 10 Hz
     _10,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// Filter bandwidth
+pub enum BANDWIDTH {
+    /// 260 Hz (Docs imply this disables the filter)
+    _260_HZ = 0,
+    /// 184 Hz
+    _184_HZ = 1,
+    /// 94 Hz
+    _94_HZ = 2,
+    /// 44 Hz
+    _44_HZ = 3,
+    /// 21 Hz
+    _21_HZ = 4,
+    /// 10 Hz
+    _10_HZ = 5,
+    /// 5 Hz
+    _5_HZ = 6,
 }
 
 #[allow(non_camel_case_types)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ### Misc
 //! * [Register sheet](https://www.invensense.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf),
 //! * [Data sheet](https://www.invensense.com/wp-content/uploads/2015/02/MPU-6500-Datasheet2.pdf)
-//! 
+//!
 //! To use this driver you must provide a concrete `embedded_hal` implementation.
 //! This example uses `linux_embedded_hal`.
 //!
@@ -50,12 +50,12 @@ mod bits;
 pub mod device;
 
 use crate::device::*;
-use libm::{powf, atan2f, sqrtf};
-use nalgebra::{Vector3, Vector2};
 use embedded_hal::{
     blocking::delay::DelayMs,
     blocking::i2c::{Write, WriteRead},
 };
+use libm::{atan2f, powf, sqrtf};
+use nalgebra::{Vector2, Vector3};
 
 /// PI, f32
 pub const PI: f32 = core::f32::consts::PI;
@@ -83,7 +83,7 @@ pub struct Mpu6050<I> {
 
 impl<I, E> Mpu6050<I>
 where
-    I: Write<Error = E> + WriteRead<Error = E>, 
+    I: Write<Error = E> + WriteRead<Error = E>,
 {
     /// Side effect free constructor with default sensitivies, no calibration
     pub fn new(i2c: I) -> Self {
@@ -116,7 +116,12 @@ where
     }
 
     /// Combination of `new_with_sens` and `new_with_addr`
-    pub fn new_with_addr_and_sens(i2c: I, slave_addr: u8, arange: AccelRange, grange: GyroRange) -> Self {
+    pub fn new_with_addr_and_sens(
+        i2c: I,
+        slave_addr: u8,
+        arange: AccelRange,
+        grange: GyroRange,
+    ) -> Self {
         Mpu6050 {
             i2c,
             slave_addr,
@@ -144,12 +149,21 @@ where
     /// (or  an  external  clocksource) as the clock reference for improved stability.
     /// The clock source can be selected according to the following table...."
     pub fn set_clock_source(&mut self, source: CLKSEL) -> Result<(), Mpu6050Error<E>> {
-        Ok(self.write_bits(PWR_MGMT_1::ADDR, PWR_MGMT_1::CLKSEL.bit, PWR_MGMT_1::CLKSEL.length, source as u8)?)
+        Ok(self.write_bits(
+            PWR_MGMT_1::ADDR,
+            PWR_MGMT_1::CLKSEL.bit,
+            PWR_MGMT_1::CLKSEL.length,
+            source as u8,
+        )?)
     }
 
     /// get current clock source
     pub fn get_clock_source(&mut self) -> Result<CLKSEL, Mpu6050Error<E>> {
-        let source = self.read_bits(PWR_MGMT_1::ADDR, PWR_MGMT_1::CLKSEL.bit, PWR_MGMT_1::CLKSEL.length)?;
+        let source = self.read_bits(
+            PWR_MGMT_1::ADDR,
+            PWR_MGMT_1::CLKSEL.bit,
+            PWR_MGMT_1::CLKSEL.length,
+        )?;
         Ok(CLKSEL::from(source))
     }
 
@@ -195,29 +209,33 @@ where
 
     /// set accel high pass filter mode
     pub fn set_accel_hpf(&mut self, mode: ACCEL_HPF) -> Result<(), Mpu6050Error<E>> {
-        Ok(
-            self.write_bits(ACCEL_CONFIG::ADDR,
-                            ACCEL_CONFIG::ACCEL_HPF.bit,
-                            ACCEL_CONFIG::ACCEL_HPF.length,
-                            mode as u8)?
-        )
+        Ok(self.write_bits(
+            ACCEL_CONFIG::ADDR,
+            ACCEL_CONFIG::ACCEL_HPF.bit,
+            ACCEL_CONFIG::ACCEL_HPF.length,
+            mode as u8,
+        )?)
     }
 
     /// get accel high pass filter mode
     pub fn get_accel_hpf(&mut self) -> Result<ACCEL_HPF, Mpu6050Error<E>> {
-        let mode: u8 = self.read_bits(ACCEL_CONFIG::ADDR,
-                                      ACCEL_CONFIG::ACCEL_HPF.bit,
-                                      ACCEL_CONFIG::ACCEL_HPF.length)?;
+        let mode: u8 = self.read_bits(
+            ACCEL_CONFIG::ADDR,
+            ACCEL_CONFIG::ACCEL_HPF.bit,
+            ACCEL_CONFIG::ACCEL_HPF.length,
+        )?;
 
         Ok(ACCEL_HPF::from(mode))
     }
 
     /// Set gyro range, and update sensitivity accordingly
     pub fn set_gyro_range(&mut self, range: GyroRange) -> Result<(), Mpu6050Error<E>> {
-        self.write_bits(GYRO_CONFIG::ADDR,
-                        GYRO_CONFIG::FS_SEL.bit,
-                        GYRO_CONFIG::FS_SEL.length,
-                        range as u8)?;
+        self.write_bits(
+            GYRO_CONFIG::ADDR,
+            GYRO_CONFIG::FS_SEL.bit,
+            GYRO_CONFIG::FS_SEL.length,
+            range as u8,
+        )?;
 
         self.gyro_sensitivity = range.sensitivity();
         Ok(())
@@ -225,19 +243,23 @@ where
 
     /// get current gyro range
     pub fn get_gyro_range(&mut self) -> Result<GyroRange, Mpu6050Error<E>> {
-        let byte = self.read_bits(GYRO_CONFIG::ADDR,
-                                  GYRO_CONFIG::FS_SEL.bit,
-                                  GYRO_CONFIG::FS_SEL.length)?;
+        let byte = self.read_bits(
+            GYRO_CONFIG::ADDR,
+            GYRO_CONFIG::FS_SEL.bit,
+            GYRO_CONFIG::FS_SEL.length,
+        )?;
 
         Ok(GyroRange::from(byte))
     }
 
     /// set accel range, and update sensitivy accordingly
     pub fn set_accel_range(&mut self, range: AccelRange) -> Result<(), Mpu6050Error<E>> {
-        self.write_bits(ACCEL_CONFIG::ADDR,
-                        ACCEL_CONFIG::FS_SEL.bit,
-                        ACCEL_CONFIG::FS_SEL.length,
-                        range as u8)?;
+        self.write_bits(
+            ACCEL_CONFIG::ADDR,
+            ACCEL_CONFIG::FS_SEL.bit,
+            ACCEL_CONFIG::FS_SEL.length,
+            range as u8,
+        )?;
 
         self.acc_sensitivity = range.sensitivity();
         Ok(())
@@ -245,9 +267,11 @@ where
 
     /// get current accel_range
     pub fn get_accel_range(&mut self) -> Result<AccelRange, Mpu6050Error<E>> {
-        let byte = self.read_bits(ACCEL_CONFIG::ADDR,
-                                  ACCEL_CONFIG::FS_SEL.bit,
-                                  ACCEL_CONFIG::FS_SEL.length)?;
+        let byte = self.read_bits(
+            ACCEL_CONFIG::ADDR,
+            ACCEL_CONFIG::FS_SEL.bit,
+            ACCEL_CONFIG::FS_SEL.length,
+        )?;
 
         Ok(AccelRange::from(byte))
     }
@@ -322,7 +346,7 @@ where
 
         Ok(Vector2::<f32>::new(
             atan2f(acc.y, sqrtf(powf(acc.x, 2.) + powf(acc.z, 2.))),
-            atan2f(-acc.x, sqrtf(powf(acc.y, 2.) + powf(acc.z, 2.)))
+            atan2f(-acc.x, sqrtf(powf(acc.y, 2.) + powf(acc.z, 2.))),
         ))
     }
 
@@ -348,7 +372,7 @@ where
         Ok(Vector3::<f32>::new(
             self.read_word_2c(&buf[0..2]) as f32,
             self.read_word_2c(&buf[2..4]) as f32,
-            self.read_word_2c(&buf[4..6]) as f32
+            self.read_word_2c(&buf[4..6]) as f32,
         ))
     }
 
@@ -381,7 +405,8 @@ where
 
     /// Writes byte to register
     pub fn write_byte(&mut self, reg: u8, byte: u8) -> Result<(), Mpu6050Error<E>> {
-        self.i2c.write(self.slave_addr, &[reg, byte])
+        self.i2c
+            .write(self.slave_addr, &[reg, byte])
             .map_err(Mpu6050Error::I2c)?;
         // delay disabled for dev build
         // TODO: check effects with physical unit
@@ -398,7 +423,13 @@ where
     }
 
     /// Write bits data at reg from start_bit to start_bit+length
-    pub fn write_bits(&mut self, reg: u8, start_bit: u8, length: u8, data: u8) -> Result<(), Mpu6050Error<E>> {
+    pub fn write_bits(
+        &mut self,
+        reg: u8,
+        start_bit: u8,
+        length: u8,
+        data: u8,
+    ) -> Result<(), Mpu6050Error<E>> {
         let mut byte: [u8; 1] = [0; 1];
         self.read_bytes(reg, &mut byte)?;
         bits::set_bits(&mut byte[0], start_bit, length, data);
@@ -422,16 +453,17 @@ where
     /// Reads byte from register
     pub fn read_byte(&mut self, reg: u8) -> Result<u8, Mpu6050Error<E>> {
         let mut byte: [u8; 1] = [0; 1];
-        self.i2c.write_read(self.slave_addr, &[reg], &mut byte)
+        self.i2c
+            .write_read(self.slave_addr, &[reg], &mut byte)
             .map_err(Mpu6050Error::I2c)?;
         Ok(byte[0])
     }
 
     /// Reads series of bytes into buf from specified reg
     pub fn read_bytes(&mut self, reg: u8, buf: &mut [u8]) -> Result<(), Mpu6050Error<E>> {
-        self.i2c.write_read(self.slave_addr, &[reg], buf)
+        self.i2c
+            .write_read(self.slave_addr, &[reg], buf)
             .map_err(Mpu6050Error::I2c)?;
         Ok(())
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,10 @@ where
     /// Wakes MPU6050 with all sensors enabled (default)
     fn wake<D: DelayMs<u8>>(&mut self, delay: &mut D) -> Result<(), Mpu6050Error<E>> {
         // MPU6050 has sleep enabled by default -> set bit 0 to wake
+        self.set_sleep_enabled(false)?;
         // Set clock source to be PLL with x-axis gyroscope reference, bits 2:0 = 001 (See Register Map )
-        self.write_byte(PWR_MGMT_1::ADDR, 0x01)?;
+        self.set_clock_source(CLKSEL::GXAXIS)?;
+
         delay.delay_ms(100u8);
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,16 @@ where
         Ok(())
     }
 
+    /// set sample rate divisor
+    pub fn set_sample_rate_divisor(&mut self, divisor: u8) -> Result<(), Mpu6050Error<E>> {
+        self.write_byte(SMPLRT_DIV, divisor)
+    }
+
+    /// get sample rate divisor
+    pub fn get_sample_rate_divisor(&mut self) -> Result<u8, Mpu6050Error<E>> {
+        self.read_byte(SMPLRT_DIV)
+    }
+
     /// From Register map:
     /// "An  internal  8MHz  oscillator,  gyroscope based  clock,or  external  sources  can  be
     /// selected  as the MPU-60X0 clock source.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,34 @@ where
         Ok(ACCEL_HPF::from(mode))
     }
 
+    /// Set cycle rate
+    pub fn set_cycle_rate(&mut self, range: CYCLE_RATE) -> Result<(), Mpu6050Error<E>> {
+        self.write_bits(
+            PWR_MGMT_2::ADDR,
+            PWR_MGMT_2::CYCLE_RATE.bit,
+            PWR_MGMT_2::CYCLE_RATE.length,
+            range as u8,
+        )?;
+        Ok(())
+    }
+
+    /// get cycle rate
+    pub fn get_cycle_rate(&mut self) -> Result<CYCLE_RATE, Mpu6050Error<E>> {
+        let rate = self.read_bits(
+            PWR_MGMT_2::ADDR,
+            PWR_MGMT_2::CYCLE_RATE.bit,
+            PWR_MGMT_2::CYCLE_RATE.length,
+        )?;
+
+        match rate {
+            0 => Ok(CYCLE_RATE::_1_25_HZ),
+            1 => Ok(CYCLE_RATE::_5_HZ),
+            2 => Ok(CYCLE_RATE::_20_HZ),
+            3 => Ok(CYCLE_RATE::_40_HZ),
+            _ => Err(Mpu6050Error::InvalidValue(rate)),
+        }
+    }
+
     /// Set gyro range, and update sensitivity accordingly
     pub fn set_gyro_range(&mut self, range: GyroRange) -> Result<(), Mpu6050Error<E>> {
         self.write_bits(
@@ -335,6 +363,16 @@ where
     /// get sleep status
     pub fn get_sleep_enabled(&mut self) -> Result<bool, Mpu6050Error<E>> {
         Ok(self.read_bit(PWR_MGMT_1::ADDR, PWR_MGMT_1::SLEEP)? != 0)
+    }
+
+    /// enable, disable cycle mode
+    pub fn set_cycle_mode(&mut self, enable: bool) -> Result<(), Mpu6050Error<E>> {
+        Ok(self.write_bit(PWR_MGMT_1::ADDR, PWR_MGMT_1::CYCLE, enable)?)
+    }
+
+    /// get cycle mode
+    pub fn get_cycle_mode(&mut self) -> Result<bool, Mpu6050Error<E>> {
+        Ok(self.read_bit(PWR_MGMT_1::CYCLE, PWR_MGMT_1::SLEEP)? != 0)
     }
 
     /// enable, disable temperature measurement of sensor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ pub enum Mpu6050Error<E> {
 
     /// Invalid chip ID was read
     InvalidChipId(u8),
+
+    /// Invalid value received
+    InvalidValue(u8),
 }
 
 /// Handles all operations on/with Mpu6050
@@ -194,6 +197,36 @@ where
             return Err(Mpu6050Error::InvalidChipId(address));
         }
         Ok(())
+    }
+
+    /// set filter bandwidth
+    pub fn set_filter_bandwidth(&mut self, bandwidth: BANDWIDTH) -> Result<(), Mpu6050Error<E>> {
+        Ok(self.write_bits(
+            CONFIG::ADDR,
+            CONFIG::BANDWIDTH.bit,
+            CONFIG::BANDWIDTH.length,
+            bandwidth as u8,
+        )?)
+    }
+
+    /// get filter bandwidth
+    pub fn get_filter_bandwidth(&mut self) -> Result<BANDWIDTH, Mpu6050Error<E>> {
+        let bandwidth: u8 = self.read_bits(
+            CONFIG::ADDR,
+            CONFIG::BANDWIDTH.bit,
+            CONFIG::BANDWIDTH.length,
+        )?;
+
+        match bandwidth {
+            0 => Ok(BANDWIDTH::_260_HZ),
+            1 => Ok(BANDWIDTH::_260_HZ),
+            2 => Ok(BANDWIDTH::_260_HZ),
+            3 => Ok(BANDWIDTH::_260_HZ),
+            4 => Ok(BANDWIDTH::_260_HZ),
+            5 => Ok(BANDWIDTH::_260_HZ),
+            6 => Ok(BANDWIDTH::_260_HZ),
+            _ => Err(Mpu6050Error::InvalidValue(bandwidth)),
+        }
     }
 
     /// setup motion detection


### PR DESCRIPTION
Hi,
1st of all, thanks for this driver :-)

While making it work (and comparing it to the C Adafriut driver for Arduino platforms), I noticed that a few configuration capabilities were missing or not explicit.

This PR adds them, one per commit.
However, an initial commit applies `rustfmt` because in my environment it happens automatically and I did not want to disable it.
I understand that ideally this should stay in a separated PR but being in a separated commit the code review is doable anyway :-)
If you are really opposed to using rustfmt (and always complying to its style) I can rewrite the PR without it.

Thanks!